### PR TITLE
share data for show and export, time range chooser refactor

### DIFF
--- a/src/widgets/graph/loading_state.rs
+++ b/src/widgets/graph/loading_state.rs
@@ -94,7 +94,11 @@ impl LoadingState {
     }
 
     pub fn is_finished(&self) -> bool {
-        return self.progress() == 1f32;
+        return self.triggered && self.progress() == 1f32;
+    }
+
+    pub fn in_progress(&self) -> bool {
+        return self.triggered && self.progress() != 1f32;
     }
 
     pub fn progress(&self) -> f32 {

--- a/src/widgets/graph/props.rs
+++ b/src/widgets/graph/props.rs
@@ -2,7 +2,7 @@ use chrono::{Date, DateTime, Duration, NaiveTime, Timelike, Utc};
 
 use crate::sources::binance::Interval;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Props {
     pub date_start: Date<Utc>,
     pub date_end: Date<Utc>,

--- a/src/windows/time_range_chooser.rs
+++ b/src/windows/time_range_chooser.rs
@@ -4,7 +4,7 @@ use super::AppWindow;
 use chrono::{Date, NaiveTime, Timelike, Utc};
 use crossbeam::channel::{unbounded, Receiver, Sender};
 use egui::{Color32, Frame, Response, Stroke, Ui, Widget, Window};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::{
     sources::binance::Interval,
@@ -180,7 +180,7 @@ impl AppWindow for TimeRangeChooser {
                                         }
                                     }
                                 } else {
-                                    error!("invalid props");
+                                    warn!("invalid props");
                                     self.valid = false;
                                 }
 
@@ -213,7 +213,7 @@ impl AppWindow for TimeRangeChooser {
                                         }
                                     }
                                 } else {
-                                    error!("invalid props");
+                                    warn!("invalid props");
                                     self.valid = false;
                                 }
                             }

--- a/src/windows/time_range_chooser.rs
+++ b/src/windows/time_range_chooser.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 
 use super::AppWindow;
-use chrono::{Date, Utc};
+use chrono::{Date, NaiveTime, Timelike, Utc};
 use crossbeam::channel::{unbounded, Receiver, Sender};
 use egui::{Color32, Frame, Response, Stroke, Ui, Widget, Window};
 use tracing::{error, info};
@@ -14,11 +14,13 @@ use crate::{
 pub struct TimeRangeChooser {
     symbol: String,
     symbol_sub: Receiver<String>,
-    props: Props,
     time_start_input: TimeInput,
     time_end_input: TimeInput,
     valid: bool,
     visible: bool,
+    date_start: Date<Utc>,
+    date_end: Date<Utc>,
+    interval: Interval,
     props_pub: Sender<Props>,
     export_pub: Sender<Props>,
 }
@@ -29,18 +31,69 @@ impl TimeRangeChooser {
         symbol_sub: Receiver<String>,
         props_pub: Sender<Props>,
         export_pub: Sender<Props>,
+        props: Props,
     ) -> Self {
         Self {
             symbol: String::new(),
             symbol_sub,
             valid: true,
             visible,
-            props: Props::default(),
             props_pub,
             export_pub,
-            time_start_input: TimeInput::new(0, 0, 0),
-            time_end_input: TimeInput::new(23, 59, 59),
+            date_start: props.date_start,
+            date_end: props.date_end,
+            interval: props.interval,
+            time_start_input: TimeInput::new(
+                props.time_start.hour(),
+                props.time_start.minute(),
+                props.time_start.second(),
+            ),
+            time_end_input: TimeInput::new(
+                props.time_end.hour(),
+                props.time_end.minute(),
+                props.time_end.second(),
+            ),
         }
+    }
+}
+
+impl TimeRangeChooser {
+    // TODO: test
+    fn parse_props(
+        time_start_opt: Option<NaiveTime>,
+        time_end_opt: Option<NaiveTime>,
+        date_start: Date<Utc>,
+        date_end: Date<Utc>,
+        interval: Interval,
+    ) -> Option<Props> {
+        let time_start: NaiveTime;
+        match time_start_opt {
+            Some(time) => {
+                time_start = time;
+            }
+            None => {
+                return None;
+            }
+        }
+
+        let time_end: NaiveTime;
+        match time_end_opt {
+            Some(time) => {
+                time_end = time;
+            }
+            None => {
+                return None;
+            }
+        }
+
+        Some(Props {
+            date_start,
+            date_end,
+            time_start,
+            time_end,
+            interval,
+            limit: 1000, // TODO: do we need to have such param?
+        })
     }
 }
 
@@ -72,14 +125,14 @@ impl AppWindow for TimeRangeChooser {
                 ui.collapsing("time period", |ui| {
                     ui.horizontal_wrapped(|ui| {
                         ui.add(
-                            egui_extras::DatePickerButton::new(&mut self.props.date_start)
+                            egui_extras::DatePickerButton::new(&mut self.date_start)
                                 .id_source("datepicker_start"),
                         );
                         ui.label("date start");
                     });
                     ui.horizontal_wrapped(|ui| {
                         ui.add(
-                            egui_extras::DatePickerButton::new(&mut self.props.date_end)
+                            egui_extras::DatePickerButton::new(&mut self.date_end)
                                 .id_source("datepicker_end"),
                         );
                         ui.label("date end");
@@ -95,15 +148,11 @@ impl AppWindow for TimeRangeChooser {
                 });
                 ui.collapsing("interval", |ui| {
                     egui::ComboBox::from_label("pick data interval")
-                        .selected_text(format!("{:?}", self.props.interval))
+                        .selected_text(format!("{:?}", self.interval))
                         .show_ui(ui, |ui| {
-                            ui.selectable_value(&mut self.props.interval, Interval::Day, "Day");
-                            ui.selectable_value(&mut self.props.interval, Interval::Hour, "Hour");
-                            ui.selectable_value(
-                                &mut self.props.interval,
-                                Interval::Minute,
-                                "Minute",
-                            );
+                            ui.selectable_value(&mut self.interval, Interval::Day, "Day");
+                            ui.selectable_value(&mut self.interval, Interval::Hour, "Hour");
+                            ui.selectable_value(&mut self.interval, Interval::Minute, "Minute");
                         });
                 });
 
@@ -111,59 +160,66 @@ impl AppWindow for TimeRangeChooser {
 
                 ui.horizontal(|ui| {
                     if ui.button("show").clicked() {
-                        let time_start = self.time_start_input.get_time();
-                        let start_valid: bool;
-                        match time_start {
-                            Some(time) => {
-                                self.props.time_start = time;
-                                start_valid = true;
+                        let props = TimeRangeChooser::parse_props(
+                            self.time_start_input.get_time(),
+                            self.time_end_input.get_time(),
+                            self.date_start,
+                            self.date_end,
+                            self.interval,
+                        );
+                        match props {
+                            Some(props) => {
+                                if props.is_valid() {
+                                    let send_result = self.props_pub.send(props);
+                                    match send_result {
+                                        Ok(_) => {
+                                            info!("sent props for show: {props:?}");
+                                        }
+                                        Err(err) => {
+                                            error!("failed to send props for show: {err}");
+                                        }
+                                    }
+                                } else {
+                                    error!("invalid props");
+                                    self.valid = false;
+                                }
+
                             }
                             None => {
-                                start_valid = false;
-                            }
-                        }
-
-                        let time_end = self.time_end_input.get_time();
-                        let end_valid: bool;
-                        match time_end {
-                            Some(time) => {
-                                self.props.time_end = time;
-                                end_valid = true;
-                            }
-                            None => {
-                                end_valid = false;
-                            }
-                        }
-
-                        if !start_valid || !end_valid {
-                            self.valid = false;
-                            return;
-                        }
-
-                        if start_valid && start_valid && !self.props.is_valid() {
-                            self.valid = false;
-                            return;
-                        }
-
-                        let send_result = self.props_pub.send(self.props);
-                        match send_result {
-                            Ok(_) => {
-                                info!("sent props for show: {:?}", self.props);
-                            }
-                            Err(err) => {
-                                error!("failed to send props for show: {err}");
+                                error!("failed to parse props");
+                                self.valid = false;
                             }
                         }
                     }
 
                     if ui.button("export").clicked() {
-                        let send_result = self.export_pub.send(self.props);
-                        match send_result {
-                            Ok(_) => {
-                                info!("sent props to export: {:?}", self.props);
+                        let props = TimeRangeChooser::parse_props(
+                            self.time_start_input.get_time(),
+                            self.time_end_input.get_time(),
+                            self.date_start,
+                            self.date_end,
+                            self.interval,
+                        );
+                        match props {
+                            Some(props) => {
+                                if props.is_valid() {
+                                    let send_result = self.export_pub.send(props);
+                                    match send_result {
+                                        Ok(_) => {
+                                            info!("sent props for export: {props:?}");
+                                        }
+                                        Err(err) => {
+                                            error!("failed to send props for export: {err}");
+                                        }
+                                    }
+                                } else {
+                                    error!("invalid props");
+                                    self.valid = false;
+                                }
                             }
-                            Err(err) => {
-                                error!("failed to send props for export: {err}");
+                            None => {
+                                error!("failed to parse props");
+                                self.valid = false;
                             }
                         }
                     };


### PR DESCRIPTION
* don't load graph if props are the same for either export or show actions
* init time range chooser with props from graph
* refactor time range chooser to parse props
* refactor error checks for time range chooser